### PR TITLE
GH-21 Create basic Translate component

### DIFF
--- a/src/components/Hello/index.tsx
+++ b/src/components/Hello/index.tsx
@@ -1,8 +1,9 @@
 import { useTranslation } from 'react-i18next';
 import logo from '~/logo.svg';
+import Translate from '../Translate';
 
 const Hello = () => {
-  const { t, i18n } = useTranslation('profile');
+  const { i18n } = useTranslation('profile');
 
   return (
     <div
@@ -33,9 +34,15 @@ const Hello = () => {
         >
           Change language to PL
         </button>
-        <li>{t('accept', { ns: 'translation' })}</li>
-        <li>{t('add', { ns: 'translation' })}</li>
-        <li>{t('myProfile')}</li>
+        <li>
+          <Translate i18n='accept' />
+        </li>
+        <li>
+          <Translate i18n='add' />
+        </li>
+        <li>
+          <Translate i18n='myProfile' ns='profile' />
+        </li>
         <li>🚀 Vite</li>
         <li>🔥 React</li>
         <li>📖 TypeScript</li>

--- a/src/components/Translate/index.tsx
+++ b/src/components/Translate/index.tsx
@@ -1,8 +1,9 @@
 import { useTranslation } from 'react-i18next';
 import { defaultNS, namespaces } from '~/i18n/config';
+import { TranslationKeys } from '~/i18n/translations/translations.types';
 
 interface IProps {
-  i18n: string; // TODO How to set proper type for this prop?
+  i18n: TranslationKeys; // TODO How to set proper type for this prop?
   ns?: typeof namespaces[number];
 }
 

--- a/src/components/Translate/index.tsx
+++ b/src/components/Translate/index.tsx
@@ -1,0 +1,17 @@
+import { useTranslation } from 'react-i18next';
+import { defaultNS, namespaces } from '~/i18n/config';
+
+interface IProps {
+  i18n: string; // TODO How to set proper type for this prop?
+  ns?: typeof namespaces[number];
+}
+
+const Translate = ({ i18n, ns = defaultNS }: IProps) => {
+  const { t } = useTranslation(ns);
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return <>{t(i18n)}</>;
+};
+
+export default Translate;

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -5,6 +5,8 @@ import enProfile from './translations/en/profile';
 import plCommon from './translations/pl/common';
 import plProfile from './translations/pl/profile';
 
+export const namespaces = ['translation', 'profile'] as const;
+
 export const defaultNS = 'translation';
 
 export const resources = {
@@ -23,7 +25,7 @@ i18n.use(initReactI18next).init({
   resources,
   lng: 'en',
   fallbackLng: 'en',
-  ns: ['translation', 'profile'],
+  ns: namespaces,
 
   interpolation: {
     escapeValue: false,

--- a/src/i18n/translations/en/common.ts
+++ b/src/i18n/translations/en/common.ts
@@ -3,4 +3,4 @@ export default {
   delete: 'Delete',
   accept: 'Accept',
   // translations above are just an example - can be deleted in the future
-} as const;
+};

--- a/src/i18n/translations/translations.types.ts
+++ b/src/i18n/translations/translations.types.ts
@@ -1,0 +1,4 @@
+import enCommon from './en/common';
+import enProfile from './en/profile';
+
+export type TranslationKeys = keyof typeof enCommon | keyof typeof enProfile;


### PR DESCRIPTION
The `Translate` component misses `i18n` key types. It should be fixed before merging it.